### PR TITLE
fix php implode function. separator comes first in the function signature

### DIFF
--- a/coveopush/Document.php
+++ b/coveopush/Document.php
@@ -121,8 +121,8 @@ class Document{
           array_push($error,'DocumentId is not a valid URL format:' . $this->DocumentId);
           $result = False;
       }
-      $this->logger->info('[Validate Document] '.implode($error,' | '));
-      return array($result, implode($error,' | '));
+      $this->logger->info('[Validate Document] '.implode(' | ', $error));
+      return array($result, implode(' | ', $error));
     }
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- minor fix for php implode function 
[implode — Join array elements with a string](https://www.php.net/manual/en/function.implode.php)