### PR TITLE
Return api calls status.

### DIFF
--- a/coveopush/BatchDocument.php
+++ b/coveopush/BatchDocument.php
@@ -6,7 +6,18 @@ namespace Coveo\Search\SDK\SDKPushPHP;
  * Class to hold the Batch Document.
  */
 class BatchDocument {
+  /**
+   * Documents to add or update.
+   *
+   * @var array
+   */
   public $AddOrUpdate = array();
+
+  /**
+   * Documents to delete.
+   *
+   * @var array
+   */
   public $Delete = array();
 
 }

--- a/coveopush/BatchPermissions.php
+++ b/coveopush/BatchPermissions.php
@@ -46,7 +46,7 @@ class BatchPermissions {
    */
   function __add(&$attr, $p_PermissionIdentityBodies) {
     // Check if correct
-    if ($p_PermissionIdentityBodies == NULL || empty($p_PermissionIdentityBodies)) {
+    if ($p_PermissionIdentityBodies === NULL || empty($p_PermissionIdentityBodies)) {
       return;
     }
 

--- a/coveopush/Document.php
+++ b/coveopush/Document.php
@@ -85,7 +85,7 @@ class Document {
    */
   function isBase64($s) {
     try {
-      return base64_encode(base64_decode($s)) == $s;
+      return base64_encode(base64_decode($s)) === $s;
     }
     catch (Exception $e) {
       return FALSE;
@@ -100,11 +100,11 @@ class Document {
   function Validate() {
     $result = TRUE;
     $error = array();
-    if ($this->permanentid == '') {
+    if ($this->permanentid === '') {
       array_push($error, 'permanentid is empty');
       $result = FALSE;
     }
-    if ($this->DocumentId == '') {
+    if ($this->DocumentId === '') {
       array_push($error, 'DocumentId is empty');
       $result = FALSE;
     }
@@ -167,7 +167,7 @@ class Document {
           }
         }
         else {
-          if ($this->{$attr} != "") {
+          if ($this->{$attr} !== "") {
             $all[$attr] = $this->{$attr};
           }
         }
@@ -206,7 +206,7 @@ class Document {
   function SetData(string $p_Data) {
     //Debug('SetData');
     // Check if empty
-    if ($p_Data == '') {
+    if ($p_Data === '') {
       $this->logger->error('[Setdata] : value not set');
       return;
     }
@@ -289,7 +289,7 @@ class Document {
   function SetContentAndZLibCompress(string $p_Content) {
     // $this->logger->debug('SetContentAndZLibCompress');
     // Check if empty
-    if ($p_Content == '') {
+    if ($p_Content === '') {
       $this->logger->error("SetContentAndZLibCompress: value not set");
       return;
     }
@@ -309,7 +309,7 @@ class Document {
    */
   function GetFileAndCompress(string $p_FilePath) {
     // Check if empty
-    if ($p_FilePath == '') {
+    if ($p_FilePath === '') {
       $this->logger->error("GetFileAndCompress: file path value not set");
       return;
     }
@@ -336,8 +336,8 @@ class Document {
    *   The fileId retrieved by the GetLargeFileContainer call.
    */
   function SetCompressedDataFileId(string $p_CompressedDataFileId) {
-    // Check if empty
-    if ($p_CompressedDataFileId == '') {
+    // Check if empty.
+    if ($p_CompressedDataFileId === '') {
       $this->logger->error("SetCompressedDataFileId: value not set");
       return;
     }
@@ -357,21 +357,21 @@ class Document {
    */
   function AddMetadata(string $p_Key, $p_Value) {
     //Debug($p_Key . ": " . mb_convert_encoding(utf8_encode($p_Value), "UTF-8", "ASCII"));
-    // Check if empty
-    if ($p_Key == '') {
+    // Check if empty.
+    if ($p_Key === '') {
       $this->logger->error("AddMetadata: key not set");
       return;
     }
 
-    // Check if in reserved keys
+    // Check if in reserved keys.
     $lower = strtolower($p_Key);
     if (array_key_exists($lower, Constants::S_DOCUMENT_RESERVED_KEYS)) {
       $this->logger->error("AddMetadata: " . $p_Key . " is a reserved field and cannot be set as metadata.");
       return;
     }
 
-    // Check if empty
-    if ($p_Value == '' || $p_Value == NULL) {
+    // Check if empty.
+    if ($p_Value === '' || $p_Value === NULL) {
       $this->logger->debug("AddMetadata: value not set for metadata key " . $p_Key);
       return;
     }
@@ -393,7 +393,7 @@ class Document {
    */
   function SetAllowedAndDeniedPermissions(array $p_AllowedPermissions, array $p_DeniedPermissions, bool $p_AllowAnonymous = NULL) {
     // Check if empty
-    if ($p_AllowedPermissions == NULL) {
+    if ($p_AllowedPermissions === NULL) {
       $this->logger->error("SetAllowedAndDeniedPermissions: AllowedPermissions not set");
       return;
     }

--- a/coveopush/DocumentPermissionSet.php
+++ b/coveopush/DocumentPermissionSet.php
@@ -61,7 +61,7 @@ class DocumentPermissionSet {
 
     //Debug('AddAllowedPermissions');
     // Check if correct
-    if ($p_PermissionIdentities == NULL || empty($p_PermissionIdentities)) {
+    if ($p_PermissionIdentities === NULL || empty($p_PermissionIdentities)) {
       return;
     }
 
@@ -84,7 +84,7 @@ class DocumentPermissionSet {
   function AddDeniedPermissions($p_PermissionIdentities) {
     //Debug('AddDeniedPermissions');
     // Check if correct
-    if ($p_PermissionIdentities == NULL || empty($p_PermissionIdentities)) {
+    if ($p_PermissionIdentities === NULL || empty($p_PermissionIdentities)) {
       return;
     }
     if (!is_array($p_PermissionIdentities)) {

--- a/coveopush/Enum.php
+++ b/coveopush/Enum.php
@@ -44,7 +44,7 @@ abstract class Enum {
    * @return array
    */
   private static function getConstants() {
-    if (self::$constCacheArray == NULL) {
+    if (self::$constCacheArray === NULL) {
       self::$constCacheArray = [];
     }
     $calledClass = get_called_class();

--- a/coveopush/PermissionIdentityBody.php
+++ b/coveopush/PermissionIdentityBody.php
@@ -71,7 +71,7 @@ class PermissionIdentityBody {
    */
   function __add(&$attr, $p_PermissionIdentities) {
     // Check if correct
-    if ($p_PermissionIdentities == NULL || empty($p_PermissionIdentities)) {
+    if ($p_PermissionIdentities === NULL || empty($p_PermissionIdentities)) {
       return;
     }
     if (!is_array($p_PermissionIdentities)) {

--- a/coveopush/PermissionIdentityBody.php
+++ b/coveopush/PermissionIdentityBody.php
@@ -46,7 +46,7 @@ class PermissionIdentityBody {
   /**
    * Default constructor used by the deserialization.
    *
-   * @param PermissionIdentityExpansion $p_Identity
+   * @param Coveo\Search\SDK\SDKPushPHP\PermissionIdentityExpansion $p_Identity
    *   Identity name.
    */
   function __construct(PermissionIdentityExpansion $p_Identity) {

--- a/coveopush/PlatformPaths.php
+++ b/coveopush/PlatformPaths.php
@@ -6,5 +6,5 @@ namespace Coveo\Search\SDK\SDKPushPHP;
  * Contains the Platform Constants used by the SDK.
  */
 class PlatformPaths {
-    const CREATE_PROVIDER = "{endpoint}/rest/organizations/{org_id}/securityproviders/{prov_id}";
+  const CREATE_PROVIDER = "{endpoint}/rest/organizations/{org_id}/securityproviders/{prov_id}";
 }

--- a/coveopush/Push.php
+++ b/coveopush/Push.php
@@ -180,9 +180,7 @@ class Push {
    */
   function __construct(string $p_SourceId, string $p_OrganizationId, string $p_ApiKey, string $p_Endpoint = NULL, $logger = NULL) {
     set_time_limit(3000);
-    if ($p_Endpoint === NULL) {
-      $p_Endpoint = PushApiEndpoint::PROD_PUSH_API_URL;
-    }
+    $p_Endpoint = $p_Endpoint ?? PushApiEndpoint::PROD_PUSH_API_URL;
 
     $this->SourceId = $p_SourceId;
     $this->OrganizationId = $p_OrganizationId;
@@ -928,9 +926,9 @@ class Push {
     if (!$valid) {
       return;
     }
-
+    $updateStatus = $updateStatus ?? TRUE;
     // Update Source Status.
-    if ($updateStatus == TRUE || $updateStatus == NULL) {
+    if ($updateStatus) {
       $this->UpdateSourceStatus(SourceStatusType::Rebuild);
     }
     // Push Document.
@@ -944,7 +942,7 @@ class Push {
       $p_CoveoDocument->Content = '';
     }
     // Update Source Status.
-    if ($updateStatus == TRUE || $updateStatus == NULL) {
+    if ($updateStatus) {
       $this->UpdateSourceStatus(SourceStatusType::Idle);
     }
   }

--- a/coveopush/Push.php
+++ b/coveopush/Push.php
@@ -1283,10 +1283,7 @@ class Push {
     if ($p_Mappings !== NULL) {
       $resourcePathFormat = PushApiPaths::PROVIDER_MAPPINGS;
     }
-
-    $values = $this->createPath();
-    $values['prov_id'] = $p_SecurityProviderId;
-    $resourcePath = $this->replacePath($resourcePathFormat, $values);
+    $resourcePath = $this->GetUrl($resourcePathFormat, $p_SecurityProviderId);
 
     $identity = $this->cleanJSON($permissionIdentityBody);
 
@@ -1387,9 +1384,7 @@ class Push {
     $this->UploadPermissions($container->UploadUri);
     $params = array(Parameters::FILE_ID => $container->FileId);
 
-    $values = $this->createPath();
-    $values['prov_id'] = $p_SecurityProviderId;
-    $resourcePath = $this->replacePath(PushApiPaths::PROVIDER_PERMISSIONS_BATCH, $values);
+    $resourcePath = $this->GetUrl(PushApiPaths::PROVIDER_PERMISSIONS_BATCH, $p_SecurityProviderId);
 
     $result = $this->doPut($resourcePath, $this->GetRequestHeaders(), NULL, $params);
 
@@ -1416,9 +1411,7 @@ class Push {
   function RemovePermissionIdentity(string $p_SecurityProviderId, PermissionIdentityExpansion $p_PermissionIdentity) {
     $permissionIdentityBody = new PermissionIdentityBody($p_PermissionIdentity);
 
-    $values = $this->createPath();
-    $values['prov_id'] = $p_SecurityProviderId;
-    $resourcePath = $this->replacePath(PushApiPaths::PROVIDER_PERMISSIONS, $values);
+    $resourcePath = $this->GetUrl(PushApiPaths::PROVIDER_PERMISSIONS, $p_SecurityProviderId);
     $identity = $this->cleanJSON($permissionIdentityBody);
 
     $result = $this->doDelete($resourcePath, $this->GetRequestHeaders(), NULL, $identity);
@@ -1447,9 +1440,8 @@ class Push {
 
     $params = array(Parameters::ORDERING_ID => $orderingId);
 
-    $values = $this->createPath();
-    $values['prov_id'] = $p_SecurityProviderId;
-    $resourcePath = $this->replacePath(PushApiPaths::PROVIDER_PERMISSIONS_DELETE, $values);
+    $resourcePath = $this->GetUrl(PushApiPaths::PROVIDER_PERMISSIONS_DELETE, $p_SecurityProviderId);
+
     $result = $this->doDelete($resourcePath, $this->GetRequestHeaders(), $params);
 
     if ($result !== FALSE) {

--- a/coveopush/Push.php
+++ b/coveopush/Push.php
@@ -180,7 +180,7 @@ class Push {
    */
   function __construct(string $p_SourceId, string $p_OrganizationId, string $p_ApiKey, string $p_Endpoint = NULL, $logger = NULL) {
     set_time_limit(3000);
-    if ($p_Endpoint == NULL) {
+    if ($p_Endpoint === NULL) {
       $p_Endpoint = PushApiEndpoint::PROD_PUSH_API_URL;
     }
 
@@ -636,7 +636,7 @@ class Push {
     $params = array();
     $url = $this->GetLargeFileContainerUrl();
     $result = $this->doPost($url, $this->GetRequestHeaders(), $params);
-    if ($result != FALSE) {
+    if ($result !== FALSE) {
       $results = new LargeFileContainer($result);
       return $results;
     }
@@ -676,11 +676,11 @@ class Push {
    */
   function UploadDocument(string $p_UploadUri, string $p_CompressedFile) {
 
-    if ($p_UploadUri == NULL) {
+    if ($p_UploadUri === NULL) {
       $this->logger->error("UploadDocument: p_UploadUri is not present");
       return;
     }
-    if ($p_CompressedFile == NULL) {
+    if ($p_CompressedFile === NULL) {
       $this->logger->error("UploadDocument: p_CompressedFile is not present");
       return;
     }
@@ -690,7 +690,7 @@ class Push {
       $p_CompressedFile = base64_decode($p_CompressedFile);
     }
     $result = $this->doPut($p_UploadUri, $this->GetRequestHeadersForS3(), $p_CompressedFile);
-    if ($result != FALSE) {
+    if ($result !== FALSE) {
       return TRUE;
     }
     else {
@@ -713,11 +713,11 @@ class Push {
    *   True if document was uploaded, false if not.
    */
   function UploadDocuments(string $p_UploadUri, array $p_ToAdd, array $p_ToDelete) {
-    if ($p_UploadUri == NULL) {
+    if ($p_UploadUri === NULL) {
       $this->logger->error("UploadDocument: p_UploadUri is not present");
       return;
     }
-    if ($p_ToAdd == NULL && $p_ToDelete == NULL) {
+    if ($p_ToAdd === NULL && $p_ToDelete === NULL) {
       $this->logger->error("UploadBatch: p_ToAdd and p_ToDelete are empty");
       return;
     }
@@ -727,7 +727,7 @@ class Push {
     $data->Delete = $p_ToDelete;
     // error_log(json_encode($data));
     $result = $this->doPut($p_UploadUri, $this->GetRequestHeadersForS3(), $this->cleanJSON($data));
-    if ($result != FALSE) {
+    if ($result !== FALSE) {
       return TRUE;
     }
     else {
@@ -743,14 +743,14 @@ class Push {
    * @return void
    */
   function UploadPermissions(string $p_UploadUri) {
-    if ($p_UploadUri == NULL) {
+    if ($p_UploadUri === NULL) {
       $this->logger->error("UploadPermissions: p_UploadUri is not present");
       return;
     }
 
     $permissions = $this->cleanJSON($this->BatchPermissions);
     $result = $this->doPut($p_UploadUri, $this->GetRequestHeadersForS3(), $permissions);
-    if ($result != FALSE) {
+    if ($result !== FALSE) {
       return TRUE;
     }
     else {
@@ -769,7 +769,7 @@ class Push {
    */
   function GetContainerAndUploadDocument(string $p_Content) {
     $container = $this->GetLargeFileContainer();
-    if ($container == NULL) {
+    if ($container === NULL) {
       $this->logger->error("GetContainerAndUploadDocument: S3 container is null");
       return;
     }
@@ -817,7 +817,7 @@ class Push {
   function AddUpdateDocumentRequest(Document $p_CoveoDocument, int $orderingId = NULL) {
     $params = array(Parameters::DOCUMENT_ID => $p_CoveoDocument->DocumentId);
 
-    if ($orderingId != NULL) {
+    if ($orderingId !== NULL) {
       $params[Parameters::ORDERING_ID] = $orderingId;
     }
     // Set the compression type parameter
@@ -828,7 +828,7 @@ class Push {
     $body = json_encode($p_CoveoDocument->cleanUp());
     // self.logger.debug(body)
     $result = $this->doPut($this->GetUpdateDocumentUrl(), $this->GetRequestHeaders(), $body, $params);
-    if ($result != FALSE) {
+    if ($result !== FALSE) {
       return TRUE;
     }
     else {
@@ -852,16 +852,16 @@ class Push {
   function DeleteDocument(string $p_DocumentId, int $orderingId = NULL, bool $deleteChildren = NULL) {
     $params = array(Parameters::DOCUMENT_ID => $p_DocumentId);
 
-    if ($orderingId != NULL) {
+    if ($orderingId !== NULL) {
       $params[Parameters::ORDERING_ID] = $orderingId;
     }
     $deleteChildren = $deleteChildren ?? FALSE;
-    if ($deleteChildren == TRUE) {
+    if ($deleteChildren === TRUE) {
       $params[Parameters::DELETE_CHILDREN] = "true";
     }
 
     $result = $this->doDelete($this->GetDeleteDocumentUrl(), $this->GetRequestHeaders(), $params);
-    if ($result != FALSE) {
+    if ($result !== FALSE) {
       return TRUE;
     }
     else {
@@ -888,7 +888,7 @@ class Push {
     }
     $params = array( Parameters::ORDERING_ID => $orderingId);
 
-    if ($queueDelay != NULL) {
+    if ($queueDelay !== NULL) {
       if (!($queueDelay >= 0 && $queueDelay <= 1440)) {
         $this->logger->error("DeleteOlderThan: queueDelay must be between 0 and 1440.");
         return;
@@ -901,7 +901,7 @@ class Push {
       $params[Parameters::QUEUE_DELAY] = 0;
     }
     $result = $this->doDelete($this->GetDeleteOlderThanUrl(), $this->GetRequestHeaders(), $params);
-    if ($result != FALSE) {
+    if ($result !== FALSE) {
       return TRUE;
     }
     else {
@@ -933,7 +933,7 @@ class Push {
     }
     // Push Document.
     try {
-      if ($p_CoveoDocument->CompressedBinaryData != '' || $p_CoveoDocument->Data != '') {
+      if ($p_CoveoDocument->CompressedBinaryData !== '' || $p_CoveoDocument->Data !== '') {
         $this->UploadDocumentIfTooLarge($p_CoveoDocument);
       }
       $this->AddUpdateDocumentRequest($p_CoveoDocument, $orderingId);
@@ -988,7 +988,7 @@ class Push {
     $params = array(Parameters::FILE_ID => $p_FileId);
     // make POST request to change status
     $result = $this->doPut($this->GetUpdateDocumentsUrl(), $this->GetRequestHeaders(), NULL, $params);
-    if ($result != FALSE) {
+    if ($result !== FALSE) {
       return TRUE;
     }
     else {
@@ -1006,7 +1006,7 @@ class Push {
    *
    */
   function UploadBatch(array $p_ToAdd, array $p_ToDelete) {
-    if ($p_ToAdd == NULL && $p_ToDelete == NULL) {
+    if ($p_ToAdd === NULL && $p_ToDelete === NULL) {
       $this->logger->error("UploadBatch: p_ToAdd and p_ToDelete are empty");
       return;
     }
@@ -1057,7 +1057,7 @@ class Push {
       else {
         // Validate each document
         list($valid, $error) = $document->Validate();
-        if ($valid == FALSE) {
+        if ($valid === FALSE) {
           return;
         }
         else {
@@ -1242,7 +1242,7 @@ class Push {
     $provider = $this->cleanJSON($secProvider);
     $p_Endpoint = $p_Endpoint ?? PlatformEndpoint::PROD_PLATFORM_API_URL;
     $result = $this->doPut($this->GetSecurityProviderUrl($p_Endpoint, $p_SecurityProviderId), $this->GetRequestHeaders(), $provider);
-    if ($result != FALSE) {
+    if ($result !== FALSE) {
       return TRUE;
     }
     else {
@@ -1275,12 +1275,12 @@ class Push {
 
     $params = array();
 
-    if ($orderingId != NULL) {
+    if ($orderingId !== NULL && $orderingId > 0 ) {
       $params[Parameters::ORDERING_ID] = $orderingId;
     }
 
     $resourcePathFormat = PushApiPaths::PROVIDER_PERMISSIONS;
-    if ($p_Mappings != NULL) {
+    if ($p_Mappings !== NULL) {
       $resourcePathFormat = PushApiPaths::PROVIDER_MAPPINGS;
     }
 
@@ -1291,7 +1291,7 @@ class Push {
     $identity = $this->cleanJSON($permissionIdentityBody);
 
     $result = $this->doPut($resourcePath, $this->GetRequestHeaders(), $identity, $params);
-    if ($result != FALSE) {
+    if ($result !== FALSE) {
       return TRUE;
     }
     else {
@@ -1397,7 +1397,7 @@ class Push {
     if ($p_DeleteOlder) {
       $this->DeletePermissionsOlderThan($p_SecurityProviderId, $this->StartOrderingId);
     }
-    if ($result != FALSE) {
+    if ($result !== FALSE) {
       return TRUE;
     }
     else {
@@ -1423,7 +1423,7 @@ class Push {
 
     $result = $this->doDelete($resourcePath, $this->GetRequestHeaders(), NULL, $identity);
 
-    if ($result != FALSE) {
+    if ($result !== FALSE) {
       return TRUE;
     }
     else {
@@ -1452,7 +1452,7 @@ class Push {
     $resourcePath = $this->replacePath(PushApiPaths::PROVIDER_PERMISSIONS_DELETE, $values);
     $result = $this->doDelete($resourcePath, $this->GetRequestHeaders(), $params);
 
-    if ($result != FALSE) {
+    if ($result !== FALSE) {
       return TRUE;
     }
     else {

--- a/coveopush/Push.php
+++ b/coveopush/Push.php
@@ -325,10 +325,10 @@ class Push {
   }
 
   /**
-   * Create an Ordering Id, used to set the order of the pushed items
+   * Create an Ordering Id, used to set the order of the pushed items.
    *
-   * @return string
-   *   The OrderingId.
+   * @return float
+   *   The batch ordering Id.
    */
   function CreateOrderingId() {
     $ordering_id = round((microtime(true) * 1000), 0);
@@ -439,6 +439,8 @@ class Push {
    *
    * @return string
    *   The status code value.
+   *
+   * @see https://docs.coveo.com/en/95/index-content/troubleshooting-push-api-error-codes
    */
   function CheckReturnCode($p_Response) {
     $this->logger->debug($p_Response['status_code']);
@@ -566,7 +568,7 @@ class Push {
    *   Request headers.
    * @param object|array $params
    *   Request parameters.
-   * @param [type] $data
+   * @param mixed $data
    *   Request data.
    *
    * @return mixed
@@ -836,19 +838,19 @@ class Push {
     }
   }
 
- /**
-  * Deletes the document.
-  *
-  * @param string $p_DocumentId
-  *   Coveo Document id.
-  * @param int|null $orderingId
-  *   Ordering Id.
-  * @param bool|null $deleteChildren
-  *   If children must be deleted.
-  *
-  * @return bool
-  *   True if the docuemnt is deleted. false if delete document request failed.
-  */
+  /**
+   * Deletes the document.
+   *
+   * @param string $p_DocumentId
+   *   Coveo Document id.
+   * @param int|null $orderingId
+   *   Ordering Id.
+   * @param bool|null $deleteChildren
+   *   If children must be deleted.
+   *
+   * @return bool
+   *   True if the docuemnt is deleted. false if delete document request failed.
+   */
   function DeleteDocument(string $p_DocumentId, int $orderingId = NULL, bool $deleteChildren = NULL) {
     $params = array(Parameters::DOCUMENT_ID => $p_DocumentId);
 
@@ -910,7 +912,7 @@ class Push {
   }
 
   /**
-   * Pushes the Document to the Push API
+   * Pushes the Document to the Push API.
    *
    * @param \Coveo\Search\SDK\SDKPushPHP\Document $p_CoveoDocument
    *   Coveo Document.
@@ -1266,6 +1268,9 @@ class Push {
    *   list of PermissionIdentityExpansion.
    * @param int|null $orderingId
    *   ordering Id.
+   *
+   * @return bool
+   *   True if request to expand permissions succeeded.
    */
   function AddPermissionExpansion(string $p_SecurityProviderId, PermissionIdentityExpansion $p_Identity, array $p_Members, array $p_Mappings, array $p_WellKnowns, int $orderingId = NULL) {
     $permissionIdentityBody = new PermissionIdentityBody($p_Identity);
@@ -1330,7 +1335,7 @@ class Push {
    * For example: Identity WIM has 3 mappings: wim@coveo.com, w@coveo.com, ad\\w
    * Add a single Permission Expansion (PermissionIdentityBody) to the Mappings
    *
-   * @param PermissionIdentityExpansion $p_Identity
+   * @param \Coveo\Search\SDK\SDKPushPHP\PermissionIdentityExpansion $p_Identity
    *   PermissionIdentityExpansion, must be the same as Identity in PermissionIdentity when pushing documents.
    * @param array $p_Members
    *   list of PermissionIdentityExpansion.
@@ -1348,9 +1353,9 @@ class Push {
   }
 
   /**
-   *  AddExpansionDeleted.Add a single Permission Expansion (PermissionIdentityBody) to the Deleted, will be deleted from the security cache
+   * Add a single Permission Expansion (PermissionIdentityBody) to the Deleted, will be deleted from the security cache.
    *
-   * @param PermissionIdentityExpansion $p_Identity
+   * @param \Coveo\Search\SDK\SDKPushPHP\PermissionIdentityExpansion $p_Identity
    *   PermissionIdentityExpansion, must be the same as Identity in PermissionIdentity when pushing documents.
    * @param array $p_Members
    *   list of PermissionIdentityExpansion.
@@ -1368,11 +1373,11 @@ class Push {
   }
 
   /**
-   *  EndExpansion will write the last batch of security updates to the push api
+   * Write the last batch of security updates to the push api.
    *
    * @param string $p_SecurityProviderId
    *   Security Provider to use.
-   * @param [type] $p_DeleteOlder
+   * @param bool|null $p_DeleteOlder
    *   (FALSE), if older documents should be removed from the index after the new push.
    */
   function EndExpansion(string $p_SecurityProviderId, bool $p_DeleteOlder = NULL) {
@@ -1405,7 +1410,7 @@ class Push {
    *
    * @param string $p_SecurityProviderId
    *   Security Provider to use.
-   * @param PermissionIdentityExpansion $p_PermissionIdentity
+   * @param \Coveo\Search\SDK\SDKPushPHP\PermissionIdentityExpansion $p_PermissionIdentity
    *   PermissionIdentityExpansion, permissionIdentity to remove.
    */
   function RemovePermissionIdentity(string $p_SecurityProviderId, PermissionIdentityExpansion $p_PermissionIdentity) {


### PR DESCRIPTION
1. Use strict identical, comparison when checking the status of a response. The response can be null or empty string in some cases and it is mistaken for FALSE.
2. Return the status for batch operations. 