### PR TITLE
use strict comparison to verify if api call is successful

### DIFF
--- a/coveopush/Push.php
+++ b/coveopush/Push.php
@@ -695,7 +695,7 @@ class Push {
       $params = array(Parameters::STATUS_TYPE => $p_SourceStatus);
 
       $result = $this->doPost($this->GetStatusUrl(), $this->GetRequestHeaders(), $params);
-      if ($result != FALSE) {
+      if ($result !== FALSE) {
         return TRUE;
       }
       else {


### PR DESCRIPTION
Use strict comparison to check if update push source status is successful (NULL response) vs failed (FALSe response).
